### PR TITLE
inDrop

### DIFF
--- a/src/java/umms/core/utils/ExperimentMap.java
+++ b/src/java/umms/core/utils/ExperimentMap.java
@@ -78,6 +78,10 @@ public class ExperimentMap {
 		return nEntries;
 	}
 
+	public Integer nExp() {
+		// dummy function to test push
+		return fileMap.size();
+	}
 	public HashMap<String,ArrayList<File>> getBamFiles() {
 		return fileMap;
 	}

--- a/src/java/umms/core/utils/ExperimentMap.java
+++ b/src/java/umms/core/utils/ExperimentMap.java
@@ -1,0 +1,88 @@
+package umms.core.utils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.List;
+import java.io.File;
+
+import umms.core.utils.InDropPreprocess;
+
+public class ExperimentMap {
+	private HashMap<String, Integer> exp2index = new HashMap<String, Integer>();   // experiment-to-index map
+	private HashMap<Integer, String> index2exp = new HashMap<Integer, String>();   // index-to-experiment map
+	private boolean singleCell = false;                   // single-cell analysis flag
+	private HashMap<String,ArrayList<File>> fileMap = new HashMap<String, ArrayList<File>>();   // experiment-to-bamfile map
+	private int nEntries = 0;
+
+	/* empty constructor */
+	public ExperimentMap() {
+	}
+	
+	/* non-single-cell constructor */
+	public ExperimentMap(HashMap<String,ArrayList<File>> bamFiles) {
+		// not single-cell data:
+		singleCell = false;
+		// Create a mapping of experiments to indices, with names sorted alphabetically:
+		List<String> expList = new ArrayList<String> (bamFiles.keySet());
+		Collections.sort(expList);
+		// Fill the exp2index and index2exp maps:
+		int i=0;
+		for (String e:expList) {
+			exp2index.put(e, i);
+			index2exp.put(i, e);
+			i++;
+		}
+		// log the number of entries in the maps:
+		nEntries = i;
+		// fill the file map:
+		fileMap = bamFiles;
+	}
+	
+	/* inDrop single-cell constructor */
+	public ExperimentMap(HashMap<String,ArrayList<File>> bamFiles, InDropPreprocess idInfo) {
+		
+		// single-cell data:
+		singleCell = true;
+		// Create a mapping of exp:barcodes to indices, with names sorted alphabetically:
+		List<String> bcList = new ArrayList<String> (idInfo.getBcCounts().keySet());
+		Collections.sort(bcList);
+		// Fill the exp2index and index2exp maps:
+		int i=0;
+		for (String bc:bcList) {
+			String bcStr = bc.toString();
+			exp2index.put(bcStr, i);
+			index2exp.put(i, bcStr);
+			i++;
+		}
+		// log the number of entries in the maps:
+		nEntries = i;
+		// fill the file map:
+		fileMap = bamFiles;
+	}	
+
+	public String getName(int idx) {
+		return index2exp.get(idx);
+	}
+	
+	public Integer getIndex(String s) {
+		if (exp2index.containsKey(s)) {
+			return exp2index.get(s);
+		} else { 
+			return -1;     // indicate that this <experiment>:<barcode> should be skipped
+		}
+	}	
+	
+	public Integer getNexp() {
+		return nEntries;
+	}
+
+	public HashMap<String,ArrayList<File>> getBamFiles() {
+		return fileMap;
+	}
+	
+	public boolean isSingleCell() {
+		return singleCell;
+	}
+}

--- a/src/java/umms/core/utils/InDropPreprocess.java
+++ b/src/java/umms/core/utils/InDropPreprocess.java
@@ -129,13 +129,13 @@ public class InDropPreprocess {
 				while (bamIterator.hasNext()) {
 					try {
 						r = bamIterator.next();
+						readCount+=1;
 						int mmCount=SAMSequenceCountingDict.getMultimapCount(r);
 						if (mmCount>1 && multimap.equals("ignore")) {
 							// skip multimapped reads if "ignore" is selected:
 							continue;
 						}
 						
-						readCount+=1;
 						// check if read start overlaps any transcript in the annotations:
 						Vector<String> oLaps = readStartOverlap(r, eMap); 
 						if (!oLaps.isEmpty()) {
@@ -272,13 +272,13 @@ public class InDropPreprocess {
 				while (bamIterator.hasNext()) {
 					try {
 						r = bamIterator.next();
+						readCount+=1;
 						int mmCount=SAMSequenceCountingDict.getMultimapCount(r);
 						if (mmCount>1 && multimap.equals("ignore")) {
 							// skip multimapped reads if "ignore" is selected:
 							continue;
 						}
 						
-						readCount+=1;
 						// check if read start overlaps any transcript in the annotations:
 						Vector<String> oLaps = readStartOverlap(r, eMap); 
 						if (!oLaps.isEmpty()) {

--- a/src/java/umms/core/utils/InDropPreprocess.java
+++ b/src/java/umms/core/utils/InDropPreprocess.java
@@ -21,6 +21,7 @@ import net.sf.samtools.SAMFormatException;
 import net.sf.samtools.SAMFileReader.ValidationStringency;
 import net.sf.samtools.SAMRecordIterator;
 
+
 //import org.apache.commons.math3.util.MultidimensionalCounter.Iterator;
 import org.apache.log4j.Logger;
 
@@ -34,6 +35,7 @@ public class InDropPreprocess {
 	static Logger logger = Logger.getLogger(InDropPreprocess.class.getName());
 	/* output pre-processed BAM files */
 	HashMap<String,ArrayList<File>> bamFiles_prep = new HashMap<String,ArrayList<File>>();
+	HashMap<String,Integer> bcCounts = new HashMap<String, Integer>();
 	
 	public InDropPreprocess(HashMap<String,ArrayList<File>> bamFiles, 
 			Map<String, Collection<Gene>> annotations, 
@@ -164,6 +166,20 @@ public class InDropPreprocess {
 		logger.info("Preprocessing complete: Total reads in: "+readsIn+" Total reads out: "+readsOut);
 	}
 	
+	public static String getBarcodeFromRead(SAMRecord r) {
+		String BC = "";	
+		// extract the well barcode and UMI:
+		String readName = r.getReadName();
+		String[] fields = readName.split(":");
+		if (fields.length == 4) {
+			BC = fields[1]+fields[2];
+		} else {
+			logger.warn("Improper read name: "+readName);
+		}
+
+		return BC;
+	}	
+	
 	/* this version of InDropPreprocess does not have a umiMin parameter, and saves the first read mapping to 
 	 * gene/barcode/umi. The barcode and UMI are assumed to be concatenated with the read ID as <readID>:<bc1>:<bc2>:<umi>: 
 	 */
@@ -271,6 +287,14 @@ public class InDropPreprocess {
 								/* write this read out as the exemplar read for this cell/transcript/UMI */
 								bamWriter.addAlignment(r);
 								writeCount+=1;
+								/* update the count for this exp:barcode */
+								String bc = getBarcodeFromRead(r);
+								String expBc = exp+":"+bc;
+								if (bcCounts.containsKey(expBc)) {
+									bcCounts.put(expBc, bcCounts.get(expBc)+1);
+								} else {
+									bcCounts.put(expBc, 1);
+								}
 							}
 						}
 					} catch (SAMFormatException e) {
@@ -297,6 +321,86 @@ public class InDropPreprocess {
 		return bamFiles_prep;
 	}
 	
+	public int fillBarcodeCounts() {
+		SAMRecord r;
+		int rCount = 0;
+		// Only fill bcCounts if it is empty:
+		if (bcCounts.isEmpty()) {
+			// If it is empty, fill it with data from PCR-duplicate-cleaned files:
+			/* open the input alignments file */
+			for (String exp:bamFiles_prep.keySet()) {
+				for (int i=0; i<bamFiles_prep.get(exp).size(); i++){
+					// open the next BAM file in the list:
+					File bamFile = (File) bamFiles_prep.get(exp).get(i);
+					logger.info("Processing file: "+bamFile+"...");
+					long loopStartTime = System.nanoTime();    // loop timer
+					SAMFileReader bamReader = new SAMFileReader(bamFile);   // open as a non-eager reader
+					// process all reads:
+					bamReader.setValidationStringency(ValidationStringency.STRICT);	
+					SAMRecordIterator bamIterator = bamReader.iterator();
+
+					while (bamIterator.hasNext()) {
+						try {
+							r = bamIterator.next();
+							rCount++;
+							/* update the count for this exp:barcode */
+							String bc = getBarcodeFromRead(r);
+							String expBc = exp+":"+bc;
+							if (bcCounts.containsKey(expBc)) {
+								bcCounts.put(expBc, bcCounts.get(expBc)+1);
+							} else {
+								bcCounts.put(expBc, 1);
+							}
+						} catch (SAMFormatException e) {
+							// skip SAM Format errors but log a warning:
+							logger.warn(e.getMessage());
+							continue;
+						}
+					}
+					bamReader.close();
+					long loopEndTime = System.nanoTime();    // loop timer
+					logger.info("Counting barcodes in file: "+bamFile+" took "+(loopEndTime-loopStartTime)/1e9+" sec\n");
+				}
+			}
+		}
+		return rCount;
+	}
+	
+	/* Remove barcodes with observations < bcMin, and return a HashMap with some statistics */
+	public HashMap<String, Integer> filterLowcountBarcodes(int bcMin) {
+		HashMap<String, Integer> bcStats = new HashMap<String, Integer>();
+		bcStats.put("startCount", bcCounts.size());  // number of barcodes before removing low counts
+		int rangeMin = Integer.MAX_VALUE;
+		int rangeMax = 0;
+		List<String> badBc = new ArrayList<String>();
+		// Find barcodes with too few reads and add them to a list:
+		for (String bc:bcCounts.keySet()) {
+			int bcN = bcCounts.get(bc);    // barcode observations
+			if (bcN < bcMin) {
+				badBc.add(bc);
+			} else {
+				if (bcN<rangeMin) {
+					rangeMin = bcN;           // smallest number of barcode observations > bcMin
+				} 	
+				if (bcN>rangeMax) {
+					rangeMax = bcN;           // largest number of barcode observations
+				}
+			}
+		}
+		
+		// remove the bad barcodes from the HashMap:
+		for (String bc:badBc) {
+			bcCounts.remove(bc);
+		}
+		
+		// fill in stats and return:
+		bcStats.put("endCount",bcCounts.size());     // number of barcodes after cleaning
+		bcStats.put("minCount", rangeMin);
+		bcStats.put("maxCount", rangeMax);
+		
+		return bcStats;
+	}
+
 	public boolean updateUmiCounts(SAMRecord r, Vector<String> oLaps, 
 			HashMap<String, HashMap<String, HashMap<String, HashMap<String, HashMap<String, Integer>>>>> umiCount,
 			int umiMin) {
@@ -519,6 +623,11 @@ public class InDropPreprocess {
 		}
 		
 		return eTree;
+	}
+	
+	// get the bcCounts map
+	public HashMap<String,Integer> getBcCounts() {
+		return bcCounts;
 	}
 	public static void main() {
 		


### PR DESCRIPTION
Major changes to allow input of multiplexed single-cell data, with all barcoded and UMI-tagged reads in a single file, rather than separating into separate input files for each cell. PCR duplicates are removed by discarding any reads for which the same barcode and UMI are mapped to the same transcript.
