### PR TITLE
Fixed a bug in the window-level read counting

### DIFF
--- a/src/java/umms/core/utils/InDropPreprocess.java
+++ b/src/java/umms/core/utils/InDropPreprocess.java
@@ -199,7 +199,7 @@ public class InDropPreprocess {
 		for (String exp:bamFiles.keySet()) {
 			
 			/* storage for well barcode/UMI counts (new for each experiment)*/
-			/* Keys: strand:chr:gene:wellBarcode:UMI:<count> */
+			/* Keys: strand:chr:gene:barcode:UMI => <count> */
 			HashMap<String, HashMap<String, HashMap<String, HashMap<String, HashMap<String, Integer>>>>> umiCount = 
 				new HashMap<String, HashMap<String, HashMap<String, HashMap<String, HashMap<String, Integer>>>>>();
 

--- a/src/java/umms/esat/NewESAT.java
+++ b/src/java/umms/esat/NewESAT.java
@@ -1164,10 +1164,16 @@ public class NewESAT {
 				    		}
 
 				    		// check if this read start is contained in any intervals in the tree:
-				    		if (windowTree.get(rStrand).containsKey(rName) && windowTree.get(rStrand).get(rName).numOverlappers(rStart, rStart+1)>0) {
-				    			Iterator<IntervalTree.Node<EventCounter>> oIter = windowTree.get(rStrand).get(rName).overlappers(rStart,rStart+1);
-				    			//logger.info("Read at "+rName+":"+rStart+" ("+rStrand+
-				    			//		") has "+windowTree.get(rStrand).get(rName).numOverlappers(rStart, rStart+1)+" overlapping intervals");
+				    		// NOTE: the reads are checked against the region rStart-1 to rStart so that reads at the right-most position
+				    		//  	in a window are placed in the window and not one base past the end of the window. This was causing a problem
+				    		//   	where a significant window was found, but the counts in the window were reported as 0, because all of the 
+				    		// 		reads were in the last base of the window.
+				    		if (windowTree.get(rStrand).containsKey(rName) && windowTree.get(rStrand).get(rName).numOverlappers(rStart-1, rStart)>0) {
+			    			Iterator<IntervalTree.Node<EventCounter>> oIter = windowTree.get(rStrand).get(rName).overlappers(rStart-1,rStart);
+				    			if (rStart==13857423) {
+				    				logger.info("Read at "+rName+":"+rStart+" ("+rStrand+") has "+
+				    						windowTree.get(rStrand).get(rName).numOverlappers(rStart-1, rStart)+" overlapping intervals");
+				    			}
 				    			while (oIter.hasNext()) {
 				    				Node<EventCounter> n = oIter.next();
 				    				// This node might contain multiple EventCounters. Update them all:


### PR DESCRIPTION
(fillExperimentWindowCounter()) that resulted in the region over which
the reads were summed was offset from the window boundaries by one base.
So, if a window spanned from X to Y, the reads were summed over the
region X-1 to Y-1.

Also, fixed some typos in InDropPreprocess.java.
