### PR TITLE
Changes:

### DIFF
--- a/src/java/umms/core/utils/InDropPreprocess.java
+++ b/src/java/umms/core/utils/InDropPreprocess.java
@@ -37,152 +37,24 @@ public class InDropPreprocess {
 	HashMap<String,ArrayList<File>> bamFiles_prep = new HashMap<String,ArrayList<File>>();
 	HashMap<String,Integer> bcCounts = new HashMap<String, Integer>();
 	
-	public InDropPreprocess(HashMap<String,ArrayList<File>> bamFiles, 
-			Map<String, Collection<Gene>> annotations, 
-			boolean qFilter, int qThresh, String multimap, int wExt, boolean stranded, String task, int umiMin) throws IOException {
-		
-		SAMRecord r;
-		SAMFileWriterFactory sf = new SAMFileWriterFactory();
-		int readsIn = 0;
-		int readsOut = 0;
-		
-		/* First, build the exon interval map */
-		HashMap<String, HashMap<String, IntervalTree<String>>> eMap = buildExonIntervalMap(annotations, wExt, stranded, task);
-		
-		/* open the input alignments file */
-		for (String exp:bamFiles.keySet()) {
-			
-			for (int i=0; i<bamFiles.get(exp).size(); i++){
-
-				long loopStartTime = System.nanoTime();    // loop timer
-
-				/* storage for well barcode/UMI counts (new for each input BAM file)*/
-				/* Keys: strand:chr:gene:wellBarcode:UMI:<count> */
-				HashMap<String, HashMap<String, HashMap<String, HashMap<String, HashMap<String, Integer>>>>> umiCount = 
-					new HashMap<String, HashMap<String, HashMap<String, HashMap<String, HashMap<String, Integer>>>>>();
-
-				// open the next BAM file in the list:
-				File bamFile = (File) bamFiles.get(exp).get(i);
-				logger.info("Processing file: "+bamFile+"...");
-				SAMFileReader bamReader = new SAMFileReader(bamFile);   // open as a non-eager reader
-				SAMFileHeader bamHeader = bamReader.getFileHeader();    // get the header information
-				
-				// create the pre-processed output BAM file:
-				// The processed file is called <original bam file base name>_nextPrep.bam
-				String inFile = bamFile.getCanonicalPath();
-				int extPos = inFile.length()-4;
-				File outFile = new File(inFile.substring(0,extPos)+"_inPrep"+inFile.substring(extPos));
-				
-				// add this file to the list of files to be processed by ESAT:
-				if (!bamFiles_prep.containsKey(exp)) {
-					bamFiles_prep.put(exp, new ArrayList<File>());
-				}
-				bamFiles_prep.get(exp).add(outFile);
-				SAMProgramRecord prepProg = new SAMProgramRecord("ESAT");
-				prepProg.setProgramVersion(PROGRAM_VERSION);
-				prepProg.setAttribute("task", task);
-				prepProg.setAttribute("wExt", ""+wExt);
-				prepProg.setAttribute("umiMin", ""+umiMin);
-				boolean makeNewPrepFile = true;     // by default, make a new file.
-				
-				// check for the existence of this file:
-				if (outFile.exists()) {
-					// open the file to read the header
-					SAMFileReader scReader = new SAMFileReader(outFile);   // open as a non-eager reader
-					SAMFileHeader scHeader = scReader.getFileHeader();    // get the header information
-					List<SAMProgramRecord> scProg = scHeader.getProgramRecords();
-					// check to make sure the ESAT parameters are the same:
-					for (SAMProgramRecord sp:scProg) {
-						String pid = sp.getProgramGroupId();
-						if (pid.equals("ESAT")) {
-							// Extract all necessary parameters:
-							String oldVer = sp.getProgramVersion();
-							String oldTask = sp.getAttribute("task");
-							int oldWExt = Integer.parseInt(sp.getAttribute("wExt"));
-							int oldUmiMin = Integer.parseInt(sp.getAttribute("umiMin"));
-							if (oldVer.equals(PROGRAM_VERSION) && oldTask.equals(task) &&
-									oldWExt==wExt && oldUmiMin==umiMin) {
-								makeNewPrepFile = false;
-							}
-						}
-					}
-				}
-
-				if (!makeNewPrepFile) {
-					// close the input file
-					bamReader.close();
-					// skip creating a new output file:
-					continue;
-				}
-				
-				// copy the header from the input BAM file:
-				bamHeader.addProgramRecord(prepProg);
-				SAMFileWriter bamWriter = sf.makeBAMWriter(bamHeader, false, outFile);
-
-				//bamReader.setValidationStringency(ValidationStringency.LENIENT);	
-				bamReader.setValidationStringency(ValidationStringency.STRICT);	
-				SAMRecordIterator bamIterator = bamReader.iterator();
-
-				int readCount = 0;
-				int writeCount = 0;
-				
-				while (bamIterator.hasNext()) {
-					try {
-						r = bamIterator.next();
-						readCount+=1;
-						int mmCount=SAMSequenceCountingDict.getMultimapCount(r);
-						if (mmCount>1 && multimap.equals("ignore")) {
-							// skip multimapped reads if "ignore" is selected:
-							continue;
-						}
-						
-						// check if read start overlaps any transcript in the annotations:
-						Vector<String> oLaps = readStartOverlap(r, eMap); 
-						if (!oLaps.isEmpty()) {
-							// if so, extract the cell barcode and UMI, and add counts for the overlapping transcript(s)
-							if (updateUmiCounts(r,oLaps,umiCount,umiMin)) {
-								/* write this read out as the exemplar read for this cell/transcript/UMI */
-								bamWriter.addAlignment(r);
-								writeCount+=1;
-							}
-						}
-					} catch (SAMFormatException e) {
-						// skip SAM Format errors but log a warning:
-						logger.warn(e.getMessage());
-						continue;
-					}
-				}
-				
-				bamReader.close();
-				bamWriter.close();
-				
-				long loopEndTime = System.nanoTime();    // loop timer
-				logger.info("Reads: "+readCount+" writes: "+writeCount);
-				logger.info("Preprocessing file: "+bamFile+" took "+(loopEndTime-loopStartTime)/1e9+" sec\n");
-				readsIn+=readCount;
-				readsOut+=writeCount;
-			}
-		}
-		logger.info("Preprocessing complete: Total reads in: "+readsIn+" Total reads out: "+readsOut);
-	}
-	
 	public static String getBarcodeFromRead(SAMRecord r) {
 		String BC = "";	
 		// extract the well barcode and UMI:
 		String readName = r.getReadName();
 		String[] fields = readName.split(":");
-		if (fields.length < 4) {
+		// New version expects <read name>:<barcode>:<UMI> (3 fields minimum):
+		if (fields.length < 3) {
 			logger.warn("Improper read name: "+readName);
 		} else {
 			int fLen = fields.length;
-			BC = fields[fLen-3]+fields[fLen-2];
+			BC = fields[fLen-2];
 		}
 
 		return BC;
 	}	
 	
 	/* this version of InDropPreprocess does not have a umiMin parameter, and saves the first read mapping to 
-	 * gene/barcode/umi. The barcode and UMI are assumed to be concatenated with the read ID as <readID>:<bc1>:<bc2>:<umi>: 
+	 * gene/barcode/umi. The barcode and UMI are assumed to be concatenated with the read ID as <readID>:<bc>:<umi>: 
 	 */
 	public InDropPreprocess(HashMap<String,ArrayList<File>> bamFiles, 
 			Map<String, Collection<Gene>> annotations, 
@@ -402,67 +274,6 @@ public class InDropPreprocess {
 		return bcStats;
 	}
 
-	public boolean updateUmiCounts(SAMRecord r, Vector<String> oLaps, 
-			HashMap<String, HashMap<String, HashMap<String, HashMap<String, HashMap<String, Integer>>>>> umiCount,
-			int umiMin) {
-		boolean writeExemplar=false;
-		
-		// HashMap keys:
-		String chr = r.getReferenceName();
-		String strand = r.getReadNegativeStrandFlag() ? "-" : "+";
-		String gName;
-		String wellBC;
-		String UMI;
-		
-		// extract the well barcode and UMI:
-		String readName = r.getReadName();
-		//String[] fields = readName.split(":");
-		//int lastField = fields.length - 1;
-		//if (fields[lastField].contains("_")) {
-		if (readName.contains("_")) {
-			//String[] wbc_umi = fields[lastField].split("_");
-			String[] wbc_umi = readName.split("_");
-			//wellBC = wbc_umi[0];	// extract the well barcode ## actually, the read name
-			wellBC = "wellBC";	    // dummy wellBC value, since cellBC is encoded in the file name
-			UMI = wbc_umi[1];		// extract the UMI
-		} else {
-			logger.warn("Improper read name: "+readName);
-			return writeExemplar;
-		}
-		
-		// update the counts:
-		// Strand key:
-		if (!umiCount.containsKey(strand)) {
-			umiCount.put(strand, new HashMap<String, HashMap<String, HashMap<String, HashMap<String, Integer>>>>());
-		}
-		// chromosome key:
-		if (!umiCount.get(strand).containsKey(chr)) {
-			umiCount.get(strand).put(chr, new HashMap<String, HashMap<String, HashMap<String, Integer>>>());
-		}
-		// gene symbol(s) keys:
-		for (String g:oLaps) {
-			if (!umiCount.get(strand).get(chr).containsKey(g)) {
-				umiCount.get(strand).get(chr).put(g, new HashMap<String, HashMap<String, Integer>>());
-			}
-			// well barcode keys:
-			if (!umiCount.get(strand).get(chr).get(g).containsKey(wellBC)) {
-				umiCount.get(strand).get(chr).get(g).put(wellBC, new HashMap<String, Integer>());
-			}
-			if (!umiCount.get(strand).get(chr).get(g).get(wellBC).containsKey(UMI)) {
-				umiCount.get(strand).get(chr).get(g).get(wellBC).put(UMI, 0);
-			}
-			// Update the counts for this gene/barcode/UMI
-			umiCount.get(strand).get(chr).get(g).get(wellBC).put(UMI,umiCount.get(strand).get(chr).get(g).get(wellBC).get(UMI)+1);
-			// If any transcript hits the UMI count threshold, set the writeExemplar flag:
-			int umiN = umiCount.get(strand).get(chr).get(g).get(wellBC).get(UMI);   // TEMPORARY
-			if (umiCount.get(strand).get(chr).get(g).get(wellBC).get(UMI)==umiMin) {
-				writeExemplar=true;
-			}
-		}
-		
-		return writeExemplar;
-	}
-	
 	/* New version without umiMin parameter */
 	public boolean updateUmiCounts(SAMRecord r, Vector<String> oLaps, 
 			HashMap<String, HashMap<String, HashMap<String, HashMap<String, HashMap<String, Integer>>>>> umiCount) {
@@ -478,12 +289,12 @@ public class InDropPreprocess {
 		// extract the well barcode and UMI:
 		String readName = r.getReadName();
 		String[] fields = readName.split(":");
-		if (fields.length < 4) {
+		if (fields.length < 3) {
 			logger.warn("Improper read name: "+readName);
 			return writeExemplar;
 		} else {
 			int fLen = fields.length;
-			BC = fields[fLen-3]+fields[fLen-2];
+			BC = fields[fLen-2];
 			UMI = fields[fLen-1];
 		}
 		
@@ -530,8 +341,13 @@ public class InDropPreprocess {
 		oLaps = new Vector<String>();	// initialize to "no overlap"
 		
 		chr = r.getReferenceName();
-		aStart = r.getAlignmentStart();
 		strand = r.getReadNegativeStrandFlag() ? "-" : "+";   // read strand
+		// negative-strand alignments 'start' at the read end:
+		if (strand.matches("\\+")) {
+			aStart = r.getAlignmentStart();
+		} else {
+			aStart = r.getAlignmentEnd();
+		}
 				
 		if (eMap.containsKey(chr)) {
 			if (eMap.get(chr).containsKey(strand)) {

--- a/src/java/umms/core/utils/NexteraPreprocess.java
+++ b/src/java/umms/core/utils/NexteraPreprocess.java
@@ -235,8 +235,13 @@ public class NexteraPreprocess {
 		oLaps = new Vector<String>();	// initialize to "no overlap"
 		
 		chr = r.getReferenceName();
-		aStart = r.getAlignmentStart();
 		strand = r.getReadNegativeStrandFlag() ? "-" : "+";   // read strand
+		// negative-strand alignments 'start' at the read end:
+		if (strand.matches("\\+")) {
+			aStart = r.getAlignmentStart();
+		} else {
+			aStart = r.getAlignmentEnd();
+		}
 				
 		if (eMap.containsKey(chr)) {
 			if (eMap.get(chr).containsKey(strand)) {

--- a/src/java/umms/esat/NewESAT.java
+++ b/src/java/umms/esat/NewESAT.java
@@ -1004,7 +1004,13 @@ public class NewESAT {
 			} else {
 				strand = "+";
 			}
-			readStart = r.getAlignmentStart();              // start location
+			
+			// negative-strand alignments 'start' at the alignment end:
+			if (strand.matches("\\+")) {
+				readStart = r.getAlignmentStart();              // start location
+			} else {
+				readStart = r.getAlignmentEnd();              // start location
+			}
 
 			// Test read start against occupancyTree:
 			if (occupancyTree.containsKey(chr)) {
@@ -1030,7 +1036,14 @@ public class NewESAT {
 			} else {
 				strand = "+";
 			}
-			readStart = r.getAlignmentStart();              // start location
+			
+			// negative-strand alignments 'start' at the alignment end:
+			if (strand.matches("\\+")) {
+				readStart = r.getAlignmentStart();              // start location
+			} else {
+				readStart = r.getAlignmentEnd();              // start location
+			}
+			
 			int oCount = occupancyTree.get(chr).get(strand).numOverlappers(readStart, readStart+1);
 			if (oCount>0) {
 				r.setAttribute("NH", 1);
@@ -1151,12 +1164,19 @@ public class NewESAT {
 						// Update the counts in cleanCountsMap if the read start location is contained in
 						// an interval in the windowTree.
 					   	rName = r.getReferenceName();                // chromosome ID
-				    	rStart = (int)(r.getAlignmentStart())-1;   // alignments are 1-based, arrays are 0-based
 				    	if (stranded & r.getReadNegativeStrandFlag()) {
 				    		rStrand = "-";
 				    	} else {
 				    		rStrand = "+";
 				    	}
+				    	
+						// negative-strand alignments 'start' at the alignment end:
+				    	if (rStrand.matches("\\+")) {
+				    		rStart = (int)(r.getAlignmentStart())-1;   // alignments are 1-based, arrays are 0-based
+				    	} else {
+				    		rStart = (int)(r.getAlignmentEnd())-1;   // alignments are 1-based, arrays are 0-based
+				    	}
+				    	
 				    	String cString = r.getCigarString(); 
 				    	// Note: if the CigarString is "*", it indicates that the read is unmapped. It would be better 
 				    	//       if SAMRecord had a isMapped() method.

--- a/src/java/umms/esat/SAMSequenceCountingDictFloat.java
+++ b/src/java/umms/esat/SAMSequenceCountingDictFloat.java
@@ -41,7 +41,14 @@ public class SAMSequenceCountingDictFloat extends SAMSequenceCountingDict {
      	
     	// Check to see if storage has already been created for this reference sequence:
     	refName = r.getReferenceName();
-    	alignStart = (int)(r.getAlignmentStart())-1;   // alignments are 1-based, arrays are 0-based
+    	
+		// negative-strand alignments 'start' at the read end:
+    	if (strand.matches("\\+")) {
+    		alignStart = (int)(r.getAlignmentStart())-1;   // alignments are 1-based, arrays are 0-based
+    	} else {
+    		alignStart = (int)(r.getAlignmentEnd())-1;   // alignments are 1-based, arrays are 0-based
+    	}
+    	
     	String cString = r.getCigarString(); 
     	// Note: if the CigarString is "*", it indicates that the read is unmapped. It would be better 
     	//       if SAMRecord had a isMapped() method.

--- a/src/java/umms/esat/SAMSequenceCountingDictShort.java
+++ b/src/java/umms/esat/SAMSequenceCountingDictShort.java
@@ -99,7 +99,13 @@ public class SAMSequenceCountingDictShort extends SAMSequenceCountingDict {
     	
     	// Check to see if storage has already been created for this reference sequence:
     	refName = r.getReferenceName();
-    	alignStart = (int)(r.getAlignmentStart())-1;   // alignments are 1-based, arrays are 0-based
+    	
+		// negative-strand alignments 'start' at the read end:
+    	if (strand.matches("\\+")) {
+    		alignStart = (int)(r.getAlignmentStart())-1;   // alignments are 1-based, arrays are 0-based
+    	} else {
+    		alignStart = (int)(r.getAlignmentEnd())-1;   // alignments are 1-based, arrays are 0-based
+    	}
     	String cString = r.getCigarString(); 
     	
     	// Note: if the CigarString is "*", it indicates that the read is unmapped. It would be better 


### PR DESCRIPTION
1) Now uses getAlignmentEnd() to get the alignment start position of
alignments on the - strand.
2) Removed outdated updateUmiCounts() method.
3) Fixed InDropPreprocess to expect <read ID>:<BC>:<UMI> insted of
2-part barcode. This should be the standard for of labeling for all
single-cell alignments in the future.
