### PR TITLE
Added -filtAT command-line switch and implementation of long-A/T filter

### DIFF
--- a/src/java/umms/core/utils/InDropPreprocess.java
+++ b/src/java/umms/core/utils/InDropPreprocess.java
@@ -58,7 +58,8 @@ public class InDropPreprocess {
 	 */
 	public InDropPreprocess(HashMap<String,ArrayList<File>> bamFiles, 
 			Map<String, Collection<Gene>> annotations, 
-			boolean qFilter, int qThresh, String multimap, int wExt, boolean stranded, String task) throws IOException {
+			boolean qFilter, int qThresh, String multimap, int wExt, boolean stranded, String task,
+			boolean filtAT, int filtAtN) throws IOException {
 		
 		SAMRecord r;
 		SAMFileWriterFactory sf = new SAMFileWriterFactory();
@@ -145,6 +146,11 @@ public class InDropPreprocess {
 				while (bamIterator.hasNext()) {
 					try {
 						r = bamIterator.next();
+						// test/count long A/T stretch reads:
+						if (filtAT && SAMSequenceCountingDict.passATFilt(r, filtAtN)) {
+							continue;
+						}
+
 						readCount+=1;
 						int mmCount=SAMSequenceCountingDict.getMultimapCount(r);
 						if (mmCount>1 && multimap.equals("ignore")) {
@@ -194,7 +200,7 @@ public class InDropPreprocess {
 		return bamFiles_prep;
 	}
 	
-	public int fillBarcodeCounts() {
+	public int fillBarcodeCounts(boolean filtAT, int filtAtN) {
 		SAMRecord r;
 		int rCount = 0;
 		// Only fill bcCounts if it is empty:
@@ -215,6 +221,11 @@ public class InDropPreprocess {
 					while (bamIterator.hasNext()) {
 						try {
 							r = bamIterator.next();
+							// test/count long A/T stretch reads:
+							if (filtAT && SAMSequenceCountingDict.passATFilt(r, filtAtN)) {
+								continue;
+							}
+							
 							rCount++;
 							/* update the count for this exp:barcode */
 							String bc = getBarcodeFromRead(r);

--- a/src/java/umms/esat/SAMSequenceCountingDict.java
+++ b/src/java/umms/esat/SAMSequenceCountingDict.java
@@ -12,8 +12,10 @@ import java.util.List;
 import java.util.Vector;
 
 
+
 import net.sf.samtools.SAMRecord;
 import net.sf.samtools.SAMSequenceDictionary;
+
 
 //import org.apache.commons.math3.util.MultidimensionalCounter.Iterator;
 import org.apache.log4j.Logger;
@@ -21,7 +23,6 @@ import org.apache.log4j.Logger;
 import broad.core.datastructures.IntervalTree;
 import broad.core.datastructures.IntervalTree.Node;
 import broad.core.math.ScanStatistics;
-
 import umms.core.annotation.Annotation;
 import umms.core.annotation.Annotation.Strand;
 import umms.core.annotation.Gene;
@@ -44,7 +45,7 @@ abstract public class SAMSequenceCountingDict extends SAMSequenceDictionary {
 	/* start counts holds the count of the number of reads that start at each base within each of the 
 	 * dictionary header entries */
 	//protected HashMap<String, short[]> startCounts = new HashMap<String, short[]>();      // **** short or float 
-	public Logger logger;
+	public static Logger logger;
     
     public SAMSequenceCountingDict () {
     	super();
@@ -673,6 +674,22 @@ abstract public class SAMSequenceCountingDict extends SAMSequenceDictionary {
     		mmCount = 1;
     	}
     	return mmCount;
+    }
+    
+    public static boolean passATFilt(SAMRecord r, int nAT) {
+    	// returns false if the read does NOT contain any stretches of As or Ts >= nAT in length.
+    	boolean retVal;
+    	String samString = r.getSAMString();
+    	// extract the sequence string from the SAM string:
+    	String[] fields = samString.split("\\s");
+    	
+    	// use regex test on sequence:
+    	if (fields[9].matches("(.*A{"+ nAT + ",}.*)|(.*T{"+ nAT + ",}.*)")) {
+    		retVal = true;
+    	} else {
+    		retVal = false;
+    	}
+    	return retVal;
     }
     
     abstract void incrementStartCounts(String refName, String strand, int alignStart, float fractCount);


### PR DESCRIPTION
in the SAMSequenceCountingDict mdoule. Aalls to the A/T filter were
added in the main module (countReadStartsFromAlignments and
fillExperimentWindowCounter) and InDropPreprocess (fillBarcodeCounts and
InDropPreprocess).
